### PR TITLE
プロジェクト名を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # 概要
+
 GoによるRESTful API作成を始めるためのガイドプロジェクトです。
 
 # 想定する読者
 
 下記についてはある程度学習済みであることを前提としています。  
 もし名前も聞いたことがないということであれば先にこれらを学習しましょう。
+
 - Go以外でWebのAPIを自作したことがある
 - GitやGitHubを利用してリポジトリを作成したり、Pull Requestを作成したことがある
 - Docker、Docker Composeを利用してMySQLなどのミドルウェアやRESTful APIを構築したことがある
 
 # 前提条件
+
 - Goをインストールしていること
   - 最悪なしでもDockerがあればハンズオンはできます
 - Dockerをインストールしていること
@@ -28,7 +31,7 @@ GoによるRESTful API作成を始めるためのガイドプロジェクトで�
 まずはこのハンズオンのリポジトリをforkしてください。  
 forkできましたら、ご自身のローカルPCにcloneしてエディタでプロジェクトを開いてください。
 
-参考: https://docs.github.com/ja/get-started/quickstart/fork-a-repo  
+参考: <https://docs.github.com/ja/get-started/quickstart/fork-a-repo>  
 
 # このプロジェクトについて
 
@@ -60,33 +63,33 @@ domain層が公開する関数を組み合わせてユースケースを実現�
 データベースなどのStorageや外部APIとのやり取りを行います。  
 ただし、このハンズオンではデータベースとのやり取りは実装しておらず、下記のように仮の実装をしています。  
 
-https://github.com/raisetech-for-student/golang-web-api-hands-on/blob/5edba42f463dea02ce1c482e78872d398361902f/infra/dao/book.go#L14-L29  
+<https://github.com/raisetech-for-student/golang-web-api-hands-on/blob/5edba42f463dea02ce1c482e78872d398361902f/infra/dao/book.go#L14-L29>  
 
 ## 利用しているライブラリやフレームワークについて
 
 ### go-chi/chiおよびgo-chi/render
 
-https://github.com/go-chi/chi  
-https://github.com/go-chi/render  
+<https://github.com/go-chi/chi>  
+<https://github.com/go-chi/render>  
 
 HTTPリクエストをハンドリングすることができます。  
 Goはnet/httpというHTTPクライアントとサーバーの実装を提供していますが、筆者が個人的にgo-chiに興味があるので採用しています。  
 
 ### cosmtrek/air
 
-https://github.com/cosmtrek/air  
+<https://github.com/cosmtrek/air>  
 
 Live Reloadを実現するために導入しています。  
 
 ### mvdan/gofumpt
 
-https://github.com/mvdan/gofumpt  
+<https://github.com/mvdan/gofumpt>  
 
 Goのstandard libraryの1つである`gofmt`よりも厳密にフォーマットするために導入しています。  
 
 ### golangci/golangci-lint
 
-https://github.com/golangci/golangci-lint  
+<https://github.com/golangci/golangci-lint>  
 
 Star数も多く、Go界隈で人気のLinterです。  
 
@@ -95,7 +98,7 @@ Star数も多く、Go界隈で人気のLinterです。
 ```
 % docker compose up
 [+] Running 1/1
- ⠿ Container dependency-injection-sample-app-1  Recreated                                                                                                                                                                          0.1s
+ ⠿ Container golang-web-api-hands-on-app-1  Recreated                                                                                                                                                                          0.1s
 Attaching to golang-web-api-hands-on
 golang-web-api-hands-on  | 
 golang-web-api-hands-on  |   __    _   ___  
@@ -147,6 +150,7 @@ Content-Length: 57
 `/books/5`でリクエストしましょう。  
 
 HTTPステータスコードが404になり、レスポンスボディとしてリソースが見つからなかったというメッセージが返却されます。  
+
 ```
 % curl -i http://localhost:8080/api/v1/books/5
 HTTP/1.1 404 Not Found
@@ -161,7 +165,7 @@ Content-Length: 33
 
 下記の箇所を修正してみましょう。  
 
-https://github.com/raisetech-for-student/golang-web-api-hands-on/blob/5edba42f463dea02ce1c482e78872d398361902f/main.go#L21-L25  
+<https://github.com/raisetech-for-student/golang-web-api-hands-on/blob/5edba42f463dea02ce1c482e78872d398361902f/main.go#L21-L25>  
 
 たとえば、`hello world`を`good morning`に修正してみてください。
 
@@ -183,6 +187,7 @@ golang-web-api-hands-on  | running...
 ## handlerの実装をしてみましょう
 
 下記リクエストを実行してレスポンスを確認してください。  
+
 ```
 % curl http://localhost:8080/message
 {"message":"There is always light behind the clouds."}
@@ -197,10 +202,11 @@ golang-web-api-hands-on  | running...
 
 実装にはGoのArraysやSlicesをどう扱うか、ArraysやSlicesからランダムに値を取り出す方法を学ぶ必要があります。  
 
-https://go.dev/tour/moretypes/7  
+<https://go.dev/tour/moretypes/7>  
 
 修正したら、下記コマンドを実行してみてください。  
 それぞれフォーマットとLintを実行します。
+
 ```
 % make fmt
 % make lint
@@ -221,43 +227,49 @@ Lintエラーが出た場合、エラーメッセージに合わせて修正し�
 下記の手順で実装しましょう。  
 
 1. `usecase/message.go`を作成し、下記を記述してください。
+
 ```go
 package usecase
 
 import (
-	"context"
+ "context"
 )
 
 type Message interface {
-	Get(ctx context.Context) string
+ Get(ctx context.Context) string
 }
 
 type messageUseCase struct{}
 
 func NewMessage() Message {
-	return &messageUseCase{}
+ return &messageUseCase{}
 }
 
 func (m *messageUseCase) Get(ctx context.Context) string {
-	return ""
+ return ""
 }
 ```
+
 2. Getメソッドの`return ""`を修正してhandlerに記述したメッセージをランダムに返す処理を移してください。  
 3. `messageHandler`の記述を修正して、usecaseのMessageを呼び出すように修正してください。  
 ※記述方法はusecase/book.goを参考にしましょう。  
 4. `main.go`の下記箇所の直前に`messageUseCase`を宣言して、`messageHandler`を使える状態にしましょう。
+
 ```go
 messageHandler := handler.NewMessage()
 ```
+
 こちらも`bookUseCase`、`bookHandler`を参考にするとよいです。  
 
 下記リクエストを実行してレスポンスを確認してください。
+
 ```
 % curl http://localhost:8080/message
 {"message":"There is always light behind the clouds."}
 ```
 
 フォーマットとLintを実行します。  
+
 ```
 % make fmt
 % make lint

--- a/domain/repository/book.go
+++ b/domain/repository/book.go
@@ -1,6 +1,6 @@
 package repository
 
-import "dependency-injection-sample/domain/model"
+import "golang-web-api-hands-on/domain/model"
 
 type Book interface {
 	FindByID(id string) *model.Book

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module dependency-injection-sample
+module golang-web-api-hands-on
 
 go 1.19
 

--- a/handler/book.go
+++ b/handler/book.go
@@ -3,8 +3,9 @@ package handler
 import (
 	"net/http"
 
-	"dependency-injection-sample/handler/response"
-	"dependency-injection-sample/usecase"
+	"golang-web-api-hands-on/handler/response"
+	"golang-web-api-hands-on/usecase"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/render"
 )

--- a/handler/response/book.go
+++ b/handler/response/book.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"dependency-injection-sample/domain/model"
+	"golang-web-api-hands-on/domain/model"
 )
 
 type Book struct {

--- a/infra/dao/book.go
+++ b/infra/dao/book.go
@@ -1,8 +1,8 @@
 package dao
 
 import (
-	"dependency-injection-sample/domain/model"
-	"dependency-injection-sample/domain/repository"
+	"golang-web-api-hands-on/domain/model"
+	"golang-web-api-hands-on/domain/repository"
 )
 
 type bookRepository struct{}

--- a/main.go
+++ b/main.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/go-chi/render"
 
-	"dependency-injection-sample/handler"
-	"dependency-injection-sample/infra/dao"
-	"dependency-injection-sample/usecase"
+	"golang-web-api-hands-on/handler"
+	"golang-web-api-hands-on/infra/dao"
+	"golang-web-api-hands-on/usecase"
+
 	"github.com/go-chi/chi/v5"
 )
 

--- a/usecase/book.go
+++ b/usecase/book.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 
-	"dependency-injection-sample/domain/model"
-	"dependency-injection-sample/domain/repository"
+	"golang-web-api-hands-on/domain/model"
+	"golang-web-api-hands-on/domain/repository"
 )
 
 type Book interface {


### PR DESCRIPTION
# 概要
プロジェクト名とリポジトリ名が異なっていたため、
プロジェクト名を`dependency-injection-sample` から`golang-web-api-hands-on`に修正しました。